### PR TITLE
启用Win32编译

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,13 +1,14 @@
 // $Id$
 // vim:ft=javascript
 
-// If your extension references something external, use ARG_WITH
-// ARG_WITH("opencc", "for opencc support", "no");
-
-// Otherwise, use ARG_ENABLE
-// ARG_ENABLE("opencc", "enable opencc support", "no");
+ARG_WITH("opencc", "for opencc support", "no");
 
 if (PHP_OPENCC != "no") {
-	EXTENSION("opencc", "opencc.c");
+	if (CHECK_LIB("opencc.lib", "opencc", PHP_OPENCC) && CHECK_HEADER_ADD_INCLUDE("opencc.h", "PHP_OPENCC", PHP_OPENCC + "\\include\\opencc")) {
+		EXTENSION("opencc", "opencc.c");
+	} else {
+		WARNING ("OpenCC headers are not found, use --with-opencc=OpenCC Base Dir(where opencc.lib located)");
+	}
+	
 }
 


### PR DESCRIPTION
环境：VS2015 Community
目标：PHP 7.0.2 源码忘记更新了，不过对API影响甚微

项|值
---|---
Build type|Release
Thread Safety|No
Compiler|MSVC14 (Visual C++ 2015)
Architecture|x64
Optimization|PGO disabled
Static analyzer|disabled

1.创建PHP的Windows编译环境，编译官方源码PHP通过后进入下一步。
参考： https://wiki.php.net/internals/windows/stepbystepbuild
没有VC14目录自己仿照现有的创建。
2.将本扩展的git仓库clone到对应版本的pecl目录下，如D:\Local\php-sdk\phpdev\vc14\x64\pecl\opencc4php。
3.下载OpenCC Win32/64（与目标对应）官方二进制包或者自己编译（我没编译出来）
https://bintray.com/byvoid/opencc/OpenCC/1.0.1/view
解压到某个位置，如D:\Local\opencc-1.0.1-win64。
4.打开VS2015 (x64) 本机工具命令提示符，如果目标是x64一定要选x64的命令行
进入D:\Local\php-sdk，运行一次`bin\phpsdk_setvars.bat`设置变量
5.进入php编译目录，如D:\Local\php-sdk\phpdev\vc14\x64\php-7.0.2-src，运行`buildconf`生成`configure.js`，通过`configure --help`确认opencc是否加入编译选项。
6.由于大部分情况下需要的是DLL，使用`configure --disable-all --disable-zts --enable-cli --with-opencc=shared,D:\Local\opencc-1.0.1-win64`做最小编译，请根据ZTS、Debug/Release与否调整相应参数，--with-opencc中的shared表示编译为共享DLL模块，否则将被编入php.dll，OpenCC目录务必填写正确。
7.配置无误，即配置总结信息中出现opencc:shared/static后，运行`nmake`开始编译。
8.根据平台、ZTS、是否调试版本，在某个输出目录中会出现`php_opencc.dll`，不再列举了。复制到php的`ext`目录、添加`php.ini`亦不再赘述。
9.由于`php_opencc.dll`本身不连接OpenCC，需要把OpenCC目录下的`opencc.dll`复制到php根目录（不是`ext`，和`php.exe`在一起），和其他DLL一个原理。
10.通过`php -m`检查是否正确加载扩展
11.在Win下使用扩展，必须使用绝对路径加载JSON配置，如`D:\Local\opencc-1.0.1-win64\t2s.json`

That's all. 如果目标和我一致可以拿走无责任成品：
https://drive.google.com/open?id=0B-cvAlivZFgkM1A4aktKTklMMXM
