### PR TITLE
fix:set zval to IS_NULL to lead memory leak

### DIFF
--- a/opencc.c
+++ b/opencc.c
@@ -99,9 +99,9 @@ PHP_FUNCTION(opencc_close)
 
 	if(res == 0) {
 		#if PHP_MAJOR_VERSION < 7
-		Z_TYPE_P(zod) = IS_NULL;
+		zend_list_delete(Z_RESVAL_P(zod));
 		#else
-		Z_TYPE_INFO_P(zod) = IS_NULL;//wtf
+		zend_list_close(Z_RES_P(zod));
 		#endif
 		RETURN_TRUE;
 	} else {


### PR DESCRIPTION
on line 102(php5) or line 104(php7), set zval zod to IS_NULL will be lead to 56 bytes memory leak on php7, a zend_resource is not be release. so i try to fix it