### PR TITLE
Fix Win32 compilation with error about opencc.h not found

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@
 ARG_WITH("opencc", "for opencc support", "no");
 
 if (PHP_OPENCC != "no") {
-	if (CHECK_LIB("opencc.lib", "opencc", PHP_OPENCC) && CHECK_HEADER_ADD_INCLUDE("opencc.h", "PHP_OPENCC", PHP_OPENCC + "\\include\\opencc")) {
+	if (CHECK_LIB("opencc.lib", "opencc", PHP_OPENCC) && CHECK_HEADER_ADD_INCLUDE("opencc.h", "CFLAGS_OPENCC", PHP_OPENCC + "\\include\\opencc")) {
 		EXTENSION("opencc", "opencc.c");
 	} else {
 		WARNING ("OpenCC headers are not found, use --with-opencc=OpenCC Base Dir(where opencc.lib located)");


### PR DESCRIPTION
有可能是之前编译环境残留文件导致未发现的typo，在全新`nmake`时发生未找到opencc.h。sorry