### PR TITLE
Use global variable to reuse resource return from  opencc_open() 

### DIFF
--- a/opencc.c
+++ b/opencc.c
@@ -78,8 +78,8 @@ PHP_FUNCTION(opencc_open)
 		RETURN_FALSE;
 	}
 
-    fprintf(stderr, "create a new opencc handler and store into global_opencc_handler[%p]\n", OPENCC_G(global_opencc_handler));
 	OPENCC_G(global_opencc_handler) = od;
+    fprintf(stderr, "create a new opencc handler and store into global_opencc_handler[%p]\n", OPENCC_G(global_opencc_handler));
 	#if PHP_MAJOR_VERSION < 7
 		RETURN_RESOURCE((long) od);
 	#else

--- a/opencc.c
+++ b/opencc.c
@@ -52,7 +52,7 @@ PHP_FUNCTION(opencc_open)
 {
 	opencc_t od = OPENCC_G(global_opencc_handler);
 	if(od != (opencc_t) -1) {
-		fprintf(stderr, "reuse opencc handler [%p]\n", od);
+		// fprintf(stderr, "reuse opencc handler [%p]\n", od);
 		#if PHP_MAJOR_VERSION < 7
 			RETURN_RESOURCE((long) od);
 		#else

--- a/opencc.c
+++ b/opencc.c
@@ -79,11 +79,12 @@ PHP_FUNCTION(opencc_open)
 	if( od == (opencc_t) -1 ) {
 		RETURN_FALSE;
 	}
+
+    fprintf(stderr, "store to global_opencc_handler[%p]\n", OPENCC_G(global_opencc_handler));
+	OPENCC_G(global_opencc_handler) = od;
 	#if PHP_MAJOR_VERSION < 7
 		RETURN_RESOURCE((long) od);
 	#else
-		OPENCC_G(global_opencc_handler) = od;
-		fprintf(stderr, "store to global_opencc_handler[%p]\n", OPENCC_G(global_opencc_handler));
 		RETURN_RES(zend_register_resource(od, le_opencc));
 	#endif
 }

--- a/opencc.c
+++ b/opencc.c
@@ -60,8 +60,6 @@ PHP_FUNCTION(opencc_open)
 		#endif
 	}
 
-	fprintf(stderr, "create a new opencc handler\n");
-
 	#if PHP_MAJOR_VERSION < 7
 		char *config = NULL;
 		int config_len;
@@ -80,7 +78,7 @@ PHP_FUNCTION(opencc_open)
 		RETURN_FALSE;
 	}
 
-    fprintf(stderr, "store to global_opencc_handler[%p]\n", OPENCC_G(global_opencc_handler));
+    fprintf(stderr, "create a new opencc handler and store into global_opencc_handler[%p]\n", OPENCC_G(global_opencc_handler));
 	OPENCC_G(global_opencc_handler) = od;
 	#if PHP_MAJOR_VERSION < 7
 		RETURN_RESOURCE((long) od);
@@ -141,6 +139,9 @@ PHP_FUNCTION(opencc_error)
 
 	const char *msg;
 	msg = opencc_error();
+	if(NULL == msg) {
+		msg="";
+	}
 	len = strlen(msg);
 
 	#if PHP_MAJOR_VERSION < 7

--- a/php_opencc.h
+++ b/php_opencc.h
@@ -49,6 +49,10 @@ ZEND_BEGIN_MODULE_GLOBALS(opencc)
 	char *global_string;
 ZEND_END_MODULE_GLOBALS(opencc)
 */
+// ref : https://devzone.zend.com/303/extension-writing-part-i-introduction-to-php-and-zend/
+ZEND_BEGIN_MODULE_GLOBALS(opencc)
+	opencc_t global_opencc_handler;
+ZEND_END_MODULE_GLOBALS(opencc)
 
 /* In every utility function you add that needs to use variables 
    in php_opencc_globals, call TSRMLS_FETCH(); after declaring other 
@@ -65,6 +69,13 @@ ZEND_END_MODULE_GLOBALS(opencc)
 #else
 #define OPENCC_G(v) (opencc_globals.v)
 #endif
+
+
+
+// ref : https://devzone.zend.com/303/extension-writing-part-i-introduction-to-php-and-zend/
+PHP_MINIT_FUNCTION(opencc);
+PHP_MSHUTDOWN_FUNCTION(opencc);
+PHP_RINIT_FUNCTION(opencc);
 
 #endif	/* PHP_OPENCC_H */
 


### PR DESCRIPTION
由於每次call opencc_open() 時, 底層的opencc library 會重新載入一次opencc的字典檔, 對php程式來說, 每一個頁都必須重新執行opencc_open()一遍, 造成系統的負荷過重. 


這個PR把opencc_open() return的值先暫存在global variable, call opencc_open()時, 祇會return global 的值, 避免重複執行opencc_open()多次. 由於同個opencc resource會被使用多次, opencc_close()改為不做任何事,  在php的MSHUTDOWN時, 再吧opencc resource close()掉. 

這個版本已經在php5 & php7在prefork model的apache 測試.對於multithread的apache 還沒有測試過, 不過根據MSHUTDOWN的定義, 應該是要可以work. 

